### PR TITLE
Fixed ERROR in CNAME Lookup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,7 @@ apt install python-certbot-nginx -y
 
 #issue new certs
 
-certbot --register-unsafely-without-email --nginx certonly --agree-tos -d $FQDN, www.$FQDN
+certbot --register-unsafely-without-email --nginx certonly --agree-tos -d $FQDN,www.$FQDN
 
 tee /etc/nginx/sites-available/$FQDN.conf > /dev/null <<EOF
 server {

--- a/install.sh
+++ b/install.sh
@@ -150,7 +150,7 @@ apt update -y
 
 apt upgrade -y
 
-apt install python-certbot-nginx -y
+apt install certbot python-certbot-nginx -y
 
 
 #issue new certs

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ DOMAIN=$(dig +short $FQDN A | sort -n )
 
 AWS_SERVICE=$(curl -s https://checkip.amazonaws.com)
 
-DOMAIN_WWW=$(dig +short www.$DOMAIN | tail -n1 )
+DOMAIN_WWW=$(dig +short www.$FQDN | tail -n1 )
 
 
 if [ "$DOMAIN" == "$AWS_SERVICE" ]

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ DOMAIN=$(dig +short $FQDN A | sort -n )
 
 AWS_SERVICE=$(curl -s https://checkip.amazonaws.com)
 
-DOMAIN_WWW=$(dig +short www.suhail.tech | tail -n1 )
+DOMAIN_WWW=$(dig +short www.$DOMAIN | tail -n1 )
 
 
 if [ "$DOMAIN" == "$AWS_SERVICE" ]

--- a/readme.md
+++ b/readme.md
@@ -36,11 +36,11 @@ wget -q -N https://raw.githubusercontent.com/chinyasuhail/nginx-auto/master/unin
 
 ## How to add an A Record and C Name Record
 
-### 1. Go to your DNS hosting provider
-### If you have forgotten your DNS hosting provider, NO PROBLEM, go to [mxtoolbox.com](https://mxtoolbox.com))
+#### 1. Go to your DNS hosting provider
+If you have forgotten your DNS hosting provider, NO PROBLEM, go to [mxtoolbox.com](https://mxtoolbox.com))
 
 
-### 2. Create an A record with your domain that points to your server's IP address.
-### Run `$ curl http://checkip.amazonaws.com` to find your server's IP address.
+#### 2. Create an A record with your domain that points to your server's IP address.
+Run `$ curl http://checkip.amazonaws.com` to find your server's IP address.
 
-### 3. Create a CNAME record of `www` that points to your domain.
+#### 3. Create a CNAME record of `www` that points to your domain.


### PR DESCRIPTION
The CNAME Lookup had been hard coded to check cname for www.suhail.tech which made it fail for all other domains.